### PR TITLE
get `./Build test` passing

### DIFF
--- a/t/document-schemas.t
+++ b/t/document-schemas.t
@@ -60,7 +60,7 @@ subtest 'bad subschemas' => sub {
   );
 
   is(
-    index($serialized, "at '/components/schemas/alpha_schema/not/minimum': got string, not number\n"), 0,
+    index($serialized, "'/components/schemas/alpha_schema/not/minimum': got string, not number\n"), 0,
     'errors serialize using the instance locations within the document',
   );
 };


### PR DESCRIPTION
Test suite was failing installing via cpanm:

    t/document-schemas.t .....
        #   Failed test 'errors serialize using the instance locations within the document'
        #   at t/document-schemas.t line 62.
        #          got: '-1'
        #     expected: '0'
        # Looks like you failed 1 test of 2.
    t/document-schemas.t ..... 1/?
    #   Failed test 'bad subschemas'
    #   at t/document-schemas.t line 66.

Stringifying the object in the debugger gave:

    62:       is(
    63:         index($serialized, "at '/components/schemas/alpha_schema/not/minimum': got string, not number\n"), 0,
    64:         'errors serialize using the instance locations within the document',
    65:       );
      DB<3> p "$serialized"
    '/components/schemas/alpha_schema/not/minimum': got string, not number
    '/components/schemas/alpha_schema/not': not all properties are valid
    '/components/schemas/alpha_schema/not': subschema 3 is not valid
    '/components/schemas/alpha_schema/not': subschema 0 is not valid
    '/components/schemas/alpha_schema': not all properties are valid
    '/components/schemas/alpha_schema': subschema 1 is not valid
    '/components/schemas/alpha_schema': subschema 0 is not valid
    '/components/schemas': not all additional properties are valid
    '/components': not all properties are valid
    '': not all properties are valid

index() didn't find the string starting with 'at ' so returned -1

This change updates the index() argument to match the string given


This project is still under active development, including undergoing
significant refactoring, so it is not accepting pull requests at this time.
Instead, please
[submit an issue](https://github.com/karenetheridge/OpenAPI-Modern/issues/new)
describing your bug or proposed change.

-------------------------
